### PR TITLE
chore: remove unused field (#109)

### DIFF
--- a/src/app/project/control-associacao/register-user-associacao/register-user-associacao.component.html
+++ b/src/app/project/control-associacao/register-user-associacao/register-user-associacao.component.html
@@ -12,13 +12,6 @@
                 <form class="mr-5" [formGroup]="form" (ngSubmit)="onSubmit()">
 
                     <div class="mt-3">
-                        <label for="type"
-                            class="font-archivo font-size-16 font-weight-medium text-secondary m-0"><b>{{"ASSOCIATION_USERS.TYPE" | translate}}</b></label>
-                        <input type="text" formControlName="type" readonly style="text-indent:20px;"
-                            class="form-control" id="type">
-                    </div>
-
-                    <div class="mt-3">
                         <label for="name"
                             class="font-archivo font-size-16 font-weight-medium text-secondary m-0"><b>{{"PROFILE.PROFILE_NAME" | translate}}</b></label>
                         <input type="text" formControlName="name" style="text-indent:20px;" class="form-control"

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -197,7 +197,7 @@
     "REGISTERED_SUPPLIERS": "Proveedores registrados",
     "ONGOING_BIDDING": "Procesos de licitación en curso",
     "DURATION": "Duración",
-    "SEND_TIEBREAKER": "Enviar para desempate"
+    "SEND_TIEBREAKER": "Enviar a desempate"
   },
   "CREATE_BIDDING_STATUS": {
     "ALL": "Todos",
@@ -290,7 +290,7 @@
     "TIEBREAKER_DATE_ERROR": "El plazo para el desempate de la licitación es de 0 a 10 días"
   },
   "ERROR_MESSAGES": {
-    "INVALID": "Campo inválido!",
+    "INVALID": "¡Campo inválido!",
     "INVALID_EMAIL": "¡Email inválido!",
     "REQUIRED_EMAIL": "¡Email es obligatorio!",
     "REQUIRED_PASSWORD": "¡Contraseña es obligatoria!",
@@ -511,7 +511,7 @@
     "FAILED": "Fallido",
     "DRAFT": "En borrador",
     "RELEASED": "Lanzado",
-    "OPEN": "Aberta",
+    "OPEN": "Abierto",
     "COMPLETED": "Abierto",
     "REOPENED": "Reabierto",
     "ASSOCIATION": "Entidad",


### PR DESCRIPTION
**Contexto**  
Na rota `pages/controle-associacao/registrar-usuario`, o campo **TIPO** dentro da seção "Usuários da Entidade" não estava sendo utilizado e foi identificado como redundante.

**O que foi feito**  
Remoção do campo **TIPO** da interface de registro de usuários da entidade.

**Como testar**  
1. Acesse a rota `pages/controle-associacao/registrar-usuario`.
2. Verifique se o campo **TIPO** não está mais visível nem presente no formulário.
3. Confirme que o restante do formulário funciona normalmente sem erros.