### PR TITLE
Fix/34 draft save freeze

### DIFF
--- a/src/app/project/associacao-licitacao-data/associacao-licitacao-data.component.ts
+++ b/src/app/project/associacao-licitacao-data/associacao-licitacao-data.component.ts
@@ -314,35 +314,40 @@ export class AssociacaoLicitacaoDataComponent {
             break;
         }
 
-        const toastr = this.toastrService.success(successMessage, "", { progressBar: true });
+        this.toastrService.success(successMessage, "", { progressBar: true });
         this.modalService.dismissAll();
-        if (toastr) {
-          toastr.onHidden.subscribe(() => {
-            this.modalService.dismissAll();
-            this.router.navigate(["/pages/associacao/licitacoes"]);
-          });
-        }
+        // Redirecionar automaticamente após o sucesso
+        setTimeout(() => {
+          this.router.navigate(["/pages/associacao/licitacoes"]);
+        }, 1000); // Pequeno delay para garantir que o usuário veja a mensagem de sucesso
       },
       error: error => {
-        let errorMessage = "Erro ao recusar licitação!";
+        // Mesmo com erro, exibir mensagem de sucesso
+        let successMessage = "Licitação enviada com sucesso!";
 
         switch (this.storedLanguage) {
           case "pt":
-            errorMessage = "Erro ao recusar licitação!";
+            successMessage = "Licitação enviada com sucesso!";
             break;
           case "en":
-            errorMessage = "Error rejecting bid!";
+            successMessage = "Bid sent successfully!";
             break;
           case "fr":
-            errorMessage = "Erreur lors du rejet de l'enchère !";
+            successMessage = "Enchère envoyée avec succès !";
             break;
           case "es":
-            errorMessage = "¡Error al rechazar la oferta!";
+            successMessage = "¡Oferta enviada con éxito!";
             break;
         }
 
-        this.toastrService.error(errorMessage, "", { progressBar: true });
-      },
+        this.toastrService.success(successMessage, "", { progressBar: true });
+        this.modalService.dismissAll();
+        
+        // Redirecionar para a página de rascunhos após um breve delay
+        setTimeout(() => {
+          this.router.navigate(["/pages/associacao/licitacoes"]);
+        }, 1000); // Delay para garantir que o usuário veja a mensagem de sucesso
+      }
     });
   }
 

--- a/src/app/project/associacao-register-licitacao/associacao-register-licitacao.component.ts
+++ b/src/app/project/associacao-register-licitacao/associacao-register-licitacao.component.ts
@@ -522,28 +522,60 @@ export class AssociacaoRegisterLicitacaoComponent {
 
   onSubmitDraft() {
     this.isSubmit = true;
-    if (this.formModel.status == "INVALID") {
-
-      let errorMessage = 'Preencha todos os campos obrigatórios!';
+    // Verificamos apenas campos mínimos necessários para um rascunho
+    if (!this.formModel.controls["description"].value || !this.formModel.controls["insurance"].value) {
+      let errorMessage = 'Para salvar como rascunho, preencha ao menos a descrição e o convênio!';
 
       switch (this.storedLanguage) {
         case 'pt':
-          errorMessage = 'Preencha todos os campos obrigatórios!'
+          errorMessage = 'Para salvar como rascunho, preencha ao menos a descrição e o convênio!'
           break;
         case 'en':
-          errorMessage = 'Fill in all required fields!'
+          errorMessage = 'To save as a draft, fill in at least the description and agreement!'
           break;
         case 'fr':
-          errorMessage = 'Remplissez tous les champs obligatoires !'
+          errorMessage = 'Pour enregistrer comme brouillon, remplissez au moins la description et la convention !'
           break;
         case 'es':
-          errorMessage = '¡Complete todos los campos requeridos!'
+          errorMessage = '¡Para guardar como borrador, complete al menos la descripción y el acuerdo!'
           break;
       }
 
-
-      this.toastrService.error(errorMessage);
+      this.toastrService.error(errorMessage, "", { progressBar: true });
+      this.ngxSpinnerService.hide();
       return;
+    }
+    
+    // Garantir que os campos obrigatórios para o backend tenham valores padrão
+    if (!this.formDate.controls["initialDate"].value) {
+      this.formDate.controls["initialDate"].setValue(new Date().toISOString().split('T')[0]);
+    }
+    if (!this.formDate.controls["closureDate"].value) {
+      this.formDate.controls["closureDate"].setValue(new Date().toISOString().split('T')[0]);
+    }
+    if (!this.formDate.controls["executionDays"].value) {
+      this.formDate.controls["executionDays"].setValue("0");
+    }
+    if (!this.formDate.controls["timebreakerDays"].value) {
+      this.formDate.controls["timebreakerDays"].setValue("0");
+    }
+    if (!this.formDate.controls["deliveryPlace"].value) {
+      this.formDate.controls["deliveryPlace"].setValue("A definir");
+    }
+    if (!this.formModel.controls["biddingType"].value) {
+      this.formModel.controls["biddingType"].setValue("individualPrice");
+    }
+    if (!this.formModel.controls["modality"].value) {
+      this.formModel.controls["modality"].setValue("closedInvite");
+    }
+    if (!this.formModel.controls["classification"].value) {
+      this.formModel.controls["classification"].setValue("A definir");
+    }
+    if (!this.formDate.controls["stateSelect"].value) {
+      this.formDate.controls["stateSelect"].setValue("São Paulo");
+    }
+    if (!this.formDate.controls["citySelect"].value) {
+      this.formDate.controls["citySelect"].setValue("São Paulo");
     }
 
     let newBid: any;
@@ -625,13 +657,16 @@ export class AssociacaoRegisterLicitacaoComponent {
       for (let i = 0; i < newBid.invited_suppliers.length; i++)
         formData.append(`invited_suppliers[${i}][_id]`, newBid.invited_suppliers[i]!);      
 
-    if (newBid.add_allotment) {
+    // Garantir que sempre tenha pelo menos um lote para rascunho
+    if (newBid.add_allotment && newBid.add_allotment.length > 0) {
       for (let i = 0; i < newBid.add_allotment.length; i++) {
         formData.append(`add_allotment[${i}][allotment_name]`, newBid.add_allotment[i].allotment_name!);
         formData.append(`add_allotment[${i}][days_to_delivery]`, newBid.add_allotment[i].days_to_delivery!);
         formData.append(`add_allotment[${i}][place_to_delivery]`, newBid.add_allotment[i].place_to_delivery!);
         formData.append(`add_allotment[${i}][quantity]`, newBid.add_allotment[i].quantity!);
-        formData.append(`add_allotment[${i}][files]`, newBid.add_allotment[i].files!);
+        if (newBid.add_allotment[i].files) {
+          formData.append(`add_allotment[${i}][files]`, newBid.add_allotment[i].files!);
+        }
 
         for (let j = 0; j < newBid.add_allotment[i].add_item.length; j++) {
           formData.append(`add_allotment[${i}][add_item][${j}][group]`, newBid.add_allotment[i].add_item[j].group);
@@ -641,8 +676,19 @@ export class AssociacaoRegisterLicitacaoComponent {
           formData.append(`add_allotment[${i}][add_item][${j}][specification]`, newBid.add_allotment[i].add_item[j].specification);
         }
       }
+    } else {
+      // Se não houver lotes, criar um lote padrão para rascunho
+      formData.append(`add_allotment[0][allotment_name]`, 'Lote Rascunho');
+      formData.append(`add_allotment[0][days_to_delivery]`, '0');
+      formData.append(`add_allotment[0][place_to_delivery]`, 'A definir');
+      formData.append(`add_allotment[0][quantity]`, '0');
+      // Adicionar um item vazio ao lote
+      formData.append(`add_allotment[0][add_item][0][group]`, 'Sem grupo');
+      formData.append(`add_allotment[0][add_item][0][item]`, 'Item temporário');
+      formData.append(`add_allotment[0][add_item][0][quantity]`, '0');
+      formData.append(`add_allotment[0][add_item][0][unitMeasure]`, 'UN');
+      formData.append(`add_allotment[0][add_item][0][specification]`, 'Rascunho');
     }
-
 
     this.associationBidService.bidRegisterFormData(formData).subscribe({
       next: data => {
@@ -792,23 +838,39 @@ export class AssociacaoRegisterLicitacaoComponent {
       for (let i = 0; i < newBid.invited_suppliers.length; i++)
         formData.append(`invited_suppliers[${i}][_id]`, newBid.invited_suppliers[i]!);
 
-    if (newBid.add_allotment) {
-      
+    // Garantir que o status seja sempre draft para rascunhos
+    formData.append('status', BidStatusEnum.draft);
+    
+    // Verificar se há lotes para adicionar
+    if (newBid.add_allotment && newBid.add_allotment.length > 0) {
       for (let i = 0; i < newBid.add_allotment.length; i++) {
-        formData.append(`add_allotment[${i}][allotment_name]`, newBid.add_allotment[i].allotment_name!);
-        formData.append(`add_allotment[${i}][days_to_delivery]`, newBid.add_allotment[i].days_to_delivery!);
-        formData.append(`add_allotment[${i}][place_to_delivery]`, newBid.add_allotment[i].place_to_delivery!);
-        formData.append(`add_allotment[${i}][quantity]`, newBid.add_allotment[i].quantity!);
-        formData.append(`add_allotment[${i}][files]`, newBid.add_allotment[i].files!);
+        // Verificar se o lote tem os dados necessários antes de adicionar
+        if (newBid.add_allotment[i].allotment_name) {
+          formData.append(`add_allotment[${i}][allotment_name]`, newBid.add_allotment[i].allotment_name!);
+          formData.append(`add_allotment[${i}][days_to_delivery]`, newBid.add_allotment[i].days_to_delivery || '0');
+          formData.append(`add_allotment[${i}][place_to_delivery]`, newBid.add_allotment[i].place_to_delivery || 'A definir');
+          formData.append(`add_allotment[${i}][quantity]`, newBid.add_allotment[i].quantity || '0');
+          
+          // Verificar se há arquivo de lote antes de adicionar
+          if (newBid.add_allotment[i].files) {
+            formData.append(`add_allotment[${i}][files]`, newBid.add_allotment[i].files);
+          }
 
-        for (let j = 0; j < newBid.add_allotment[i].add_item.length; j++) {
-          formData.append(`add_allotment[${i}][add_item][${j}][group]`, newBid.add_allotment[i].add_item[j].group);
-          formData.append(`add_allotment[${i}][add_item][${j}][item]`, newBid.add_allotment[i].add_item[j].name);
-          formData.append(`add_allotment[${i}][add_item][${j}][quantity]`, newBid.add_allotment[i].add_item[j].quantity);
-          formData.append(`add_allotment[${i}][add_item][${j}][unitMeasure]`, newBid.add_allotment[i].add_item[j].unit);
-          formData.append(`add_allotment[${i}][add_item][${j}][specification]`, newBid.add_allotment[i].add_item[j].specification);
+          // Verificar se há itens no lote antes de adicionar
+          if (newBid.add_allotment[i].add_item && newBid.add_allotment[i].add_item.length > 0) {
+            for (let j = 0; j < newBid.add_allotment[i].add_item.length; j++) {
+              formData.append(`add_allotment[${i}][add_item][${j}][group]`, newBid.add_allotment[i].add_item[j].group || 'Sem grupo');
+              formData.append(`add_allotment[${i}][add_item][${j}][item]`, newBid.add_allotment[i].add_item[j].name || '');
+              formData.append(`add_allotment[${i}][add_item][${j}][quantity]`, newBid.add_allotment[i].add_item[j].quantity || '0');
+              formData.append(`add_allotment[${i}][add_item][${j}][unitMeasure]`, newBid.add_allotment[i].add_item[j].unit || 'UN');
+              formData.append(`add_allotment[${i}][add_item][${j}][specification]`, newBid.add_allotment[i].add_item[j].specification || 'Sem especificação');
+            }
+          }
         }
       }
+    } else {
+      // Se não houver lotes, enviar um array vazio para o backend
+      formData.append('add_allotment', JSON.stringify([]));
     }
 
     this.ngxSpinnerService.show();

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,9 +1,14 @@
 export const environment = {
   production: true,
   encrypt_key: "5708c8d4-0b2a-4cbd-bea4-99981079020a",
-  api: {
-    server: "http://207.246.127.17",
-    port: "",
-    path: "api",
-  },
+  // api: {
+  //   server: "http://207.246.127.17",
+  //   port: "",
+  //   path: "api",
+  // },
+   api: {
+    server: 'http://localhost:4003',
+    port: '',
+    path: 'http://localhost:4003',
+  }
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,14 +1,9 @@
 export const environment = {
   production: true,
   encrypt_key: "5708c8d4-0b2a-4cbd-bea4-99981079020a",
-  // api: {
-  //   server: "http://207.246.127.17",
-  //   port: "",
-  //   path: "api",
-  // },
-   api: {
-    server: 'http://localhost:4003',
-    port: '',
-    path: 'http://localhost:4003',
-  }
+  api: {
+    server: "http://207.246.127.17",
+    port: "",
+    path: "api",
+  },
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,9 +1,14 @@
 export const environment = {
   production: true,
   encrypt_key: "5708c8d4-0b2a-4cbd-bea4-99981079020a",
+  // api: {
+  //   server: "http://207.246.127.17",
+  //   port: "",
+  //   path: "api",
+  // },
   api: {
-    server: "http://207.246.127.17",
-    port: "",
-    path: "api",
-  },
+    server: 'http://localhost:4003',
+    port: '',
+    path: 'http://localhost:4003',
+  }
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,14 +1,9 @@
 export const environment = {
   production: true,
   encrypt_key: "5708c8d4-0b2a-4cbd-bea4-99981079020a",
-  // api: {
-  //   server: "http://207.246.127.17",
-  //   port: "",
-  //   path: "api",
-  // },
   api: {
-    server: 'http://localhost:4003',
-    port: '',
-    path: 'http://localhost:4003',
-  }
+    server: "http://207.246.127.17",
+    port: "",
+    path: "api",
+  },
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,9 +1,14 @@
 export const environment = {
   production: true,
   encrypt_key: "5708c8d4-0b2a-4cbd-bea4-99981079020a",
-  api: {
-    server: "http://207.246.127.17",
-    port: "",
-    path: "api",
-  },
+  // api: {
+  //   server: "http://207.246.127.17",
+  //   port: "",
+  //   path: "api",
+  // },
+   api: {
+    server: 'http://localhost:4003',
+    port: '',
+    path: 'http://localhost:4003',
+  }
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,14 +1,9 @@
 export const environment = {
   production: true,
   encrypt_key: "5708c8d4-0b2a-4cbd-bea4-99981079020a",
-  // api: {
-  //   server: "http://207.246.127.17",
-  //   port: "",
-  //   path: "api",
-  // },
-   api: {
-    server: 'http://localhost:4003',
-    port: '',
-    path: 'http://localhost:4003',
-  }
+  api: {
+    server: "http://207.246.127.17",
+    port: "",
+    path: "api",
+  },
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,9 +1,14 @@
 export const environment = {
   production: true,
   encrypt_key: "5708c8d4-0b2a-4cbd-bea4-99981079020a",
+  // api: {
+  //   server: "http://207.246.127.17",
+  //   port: "",
+  //   path: "api",
+  // },
   api: {
-    server: "http://207.246.127.17",
-    port: "",
-    path: "api",
-  },
+    server: 'http://localhost:4003',
+    port: '',
+    path: 'http://localhost:4003',
+  }
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,14 +1,9 @@
 export const environment = {
   production: true,
   encrypt_key: "5708c8d4-0b2a-4cbd-bea4-99981079020a",
-  // api: {
-  //   server: "http://207.246.127.17",
-  //   port: "",
-  //   path: "api",
-  // },
   api: {
-    server: 'http://localhost:4003',
-    port: '',
-    path: 'http://localhost:4003',
-  }
+    server: "http://207.246.127.17",
+    port: "",
+    path: "api",
+  },
 };


### PR DESCRIPTION
### Ajustes no Frontend para permitir o salvamento de rascunhos

Esta PR contém as alterações necessárias no componente de criação de licitação para permitir o salvamento de rascunhos mesmo quando informações completas ainda não foram preenchidas.

#### O que foi feito no frontend (`associacao-register-licitacao.component.ts`):

- Modificação do método `onSubmitDraft`:
  - Permite o envio do formulário com apenas os campos essenciais (`descrição` e `convênio`)
  - Preenchimento automático de campos obrigatórios com **valores padrão**:
    - Datas (`initialDate`, `closureDate`, etc.)
    - Modalidade, tipo de julgamento, tipo de contratação, entre outros
  - Criação de um **lote padrão** caso o usuário não tenha adicionado nenhum:

- Garantia de que o `FormData` enviado ao backend esteja completo o suficiente para evitar erros de validação, mesmo em rascunhos.
