### PR TITLE
fix: fix status field submission on bid creation

### DIFF
--- a/src/app/project/associacao-register-licitacao/associacao-register-licitacao.component.ts
+++ b/src/app/project/associacao-register-licitacao/associacao-register-licitacao.component.ts
@@ -839,7 +839,7 @@ export class AssociacaoRegisterLicitacaoComponent {
         formData.append(`invited_suppliers[${i}][_id]`, newBid.invited_suppliers[i]!);
 
     // Garantir que o status seja sempre draft para rascunhos
-    formData.append('status', BidStatusEnum.draft);
+    // Removido append duplicado de status para evitar envio como array
     
     // Verificar se há lotes para adicionar
     if (newBid.add_allotment && newBid.add_allotment.length > 0) {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,5 +5,5 @@ export const environment = {
     server: "http://207.246.127.17",
     port: "",
     path: "api",
-  },
+  }
 };


### PR DESCRIPTION
## Bug Fix: Status Field on Bid Creation (Task 34)

### Problema  
Ao criar uma licitação, o campo `status` estava sendo enviado como um array (`["awaiting", "draft"]`) no FormData, em vez de uma string. Isso acontecia porque o status era adicionado duas vezes no FormData, uma para cada possível valor. Como consequência, o backend retornava erro de validação:

Bids validation failed: status: Cast to string failed for value "[ 'awaiting', 'draft' ]" (type Array) at path "status"

### Solução  
Foi ajustado o código do frontend para garantir que o campo `status` seja adicionado ao FormData **apenas uma vez**, de acordo com a ação do usuário:  
- Se o usuário clicar em **"Salvar Rascunho"**, o status é enviado como `"draft"`  
- Se o usuário clicar em **"Finalizar e enviar para liberação"**, o status é enviado como `"awaiting"`  

### Resultado  
O backend agora recebe o valor correto do campo `status` como uma string, e o erro de validação foi resolvido.
