### PR TITLE
Feat/181 validacao cnpj alfanumerico

### DIFF
--- a/src/app/accounts/register-supplier/register-supplier.component.html
+++ b/src/app/accounts/register-supplier/register-supplier.component.html
@@ -102,6 +102,11 @@
                                             translate }}
                                         </p>
                                     </div>
+                                    <div *ngIf="form.controls['mainCnpj'].errors?.['invalidCnpj'] && (form.controls['mainCnpj'].touched || isSubmit)"
+                                        class="div-msg-error mt-2">
+                                        <img src="../../../assets/images/icon-alert.svg" class="img-msg-error" alt="">
+                                        <p class="font-poppins font-size-14 m-0">CNPJ inválido (antigo ou novo padrão).</p>
+                                    </div>
                                 </div>
 
                                 <div *ngIf="form.controls['type']?.value == 'cpf'" class="col-md-6 col-sm-12 mt-3">

--- a/src/app/accounts/register-supplier/register-supplier.component.ts
+++ b/src/app/accounts/register-supplier/register-supplier.component.ts
@@ -18,6 +18,15 @@ import { TranslateService } from "@ngx-translate/core";
 import UserDataValidator from "src/utils/user-data-validator.utils";
 import { Location } from '@angular/common';
 
+// Validador customizado para CNPJ (antigo e novo)
+export function cnpjValidator(): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value;
+    if (!value) return null;
+    return UserDataValidator.validarCNPJ(value) ? null : { invalidCnpj: true };
+  };
+}
+
 @Component({
   selector: 'app-register-supplier',
   templateUrl: './register-supplier.component.html',
@@ -69,7 +78,7 @@ export class RegisterSupplierComponent implements OnInit {
       name: ["", [Validators.required]],
       nationality: [""],
       maritalStatus: [""],
-      mainCnpj: ["", [Validators.minLength(14)]],
+      mainCnpj: ["", [Validators.minLength(14), cnpjValidator()]],
       mainCpf: ["", [Validators.minLength(11)]],
       type: ["", [Validators.required]],
     });

--- a/src/app/accounts/register-supplier/register-supplier.component.ts
+++ b/src/app/accounts/register-supplier/register-supplier.component.ts
@@ -235,7 +235,7 @@ export class RegisterSupplierComponent implements OnInit {
     };
 
     if (isCnpj) {
-      newSupplier.cnpj = mainCnpj;
+      newSupplier.cnpj = mainCnpj.replace(/[^a-zA-Z0-9]/g, '');
     } else {
       newSupplier.cpf = mainCpf.replace(/[^0-9]/g, '');
     }

--- a/src/app/accounts/register-supplier/register-supplier.component.ts
+++ b/src/app/accounts/register-supplier/register-supplier.component.ts
@@ -218,21 +218,27 @@ export class RegisterSupplierComponent implements OnInit {
       return this.cancelSubmit();
     }
 
-    const document = this.form.controls["mainCnpj"]?.value
-      ? this.form.controls["mainCnpj"]?.value
-      : this.form.controls["mainCpf"]?.value;
+    const isCnpj = this.form.controls["type"].value === "cnpj";
+    const mainCnpj = this.form.controls["mainCnpj"]?.value;
+    const mainCpf = this.form.controls["mainCpf"]?.value;
 
-    if (!document) return this.cancelSubmit();
+    if (isCnpj && !mainCnpj) return this.cancelSubmit();
+    if (!isCnpj && !mainCpf) return this.cancelSubmit();
 
     const newSupplier: SupplierRegisterDto = {
       name: this.form.controls["name"].value,
-      cpf: document.replace(/[^0-9]/g, ''),
-      type: this.form.controls["type"].value === "cpf" ? "pessoa_fisica" : "pessoa_juridica",
+      type: isCnpj ? "pessoa_juridica" : "pessoa_fisica",
       group_id: this.formCategoryAndSegments.controls["categories"].value,
       address: new AddressDto(),
       legal_representative: new LegalRepresentativeDto(),
       categoriesId: this.selectCategoriesAndSegments?.map(category => category._id || "") || [],
     };
+
+    if (isCnpj) {
+      newSupplier.cnpj = mainCnpj;
+    } else {
+      newSupplier.cpf = mainCpf.replace(/[^0-9]/g, '');
+    }
 
     newSupplier.address.city = this.formAddress.controls["city"].value;
     newSupplier.address.complement = this.formAddress.controls["complement"].value;

--- a/src/app/accounts/register-supplier/register-supplier.component.ts
+++ b/src/app/accounts/register-supplier/register-supplier.component.ts
@@ -19,7 +19,7 @@ import UserDataValidator from "src/utils/user-data-validator.utils";
 import { Location } from '@angular/common';
 
 // Validador customizado para CNPJ (antigo e novo)
-export function cnpjValidator(): ValidatorFn {
+export function is_valid_cnpj(): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     const value = control.value;
     if (!value) return null;
@@ -78,7 +78,7 @@ export class RegisterSupplierComponent implements OnInit {
       name: ["", [Validators.required]],
       nationality: [""],
       maritalStatus: [""],
-      mainCnpj: ["", [Validators.minLength(14), cnpjValidator()]],
+      mainCnpj: ["", [Validators.minLength(14), is_valid_cnpj()]],
       mainCpf: ["", [Validators.minLength(11)]],
       type: ["", [Validators.required]],
     });

--- a/src/dtos/supplier/supplier-register-request.dto.ts
+++ b/src/dtos/supplier/supplier-register-request.dto.ts
@@ -4,8 +4,9 @@ import { SuplierTypeEnum } from "./supplier-type.enum";
 
 export class SupplierRegisterDto {
 
-    name: string
-    cpf: string;
+    name: string;
+    cpf?: string;
+    cnpj?: string;
     type: string;
     address: AddressDto;
     legal_representative: LegalRepresentativeDto;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -5,5 +5,5 @@ export const environment = {
     server: "http://207.246.127.17",
     port: "",
     path: "api",
-  },
+  }
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,9 +1,14 @@
 export const environment = {
   production: true,
   encrypt_key: "5708c8d4-0b2a-4cbd-bea4-99981079020a",
+  // api: {
+  //   server: "http://207.246.127.17",
+  //   port: "",
+  //   path: "api",
+  // },
   api: {
-    server: "http://207.246.127.17",
-    port: "",
-    path: "api",
-  },
+    server: 'http://localhost:4003',
+    port: '',
+    path: 'http://localhost:4003',
+  }
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,14 +1,9 @@
 export const environment = {
   production: true,
   encrypt_key: "5708c8d4-0b2a-4cbd-bea4-99981079020a",
-  // api: {
-  //   server: "http://207.246.127.17",
-  //   port: "",
-  //   path: "api",
-  // },
   api: {
-    server: 'http://localhost:4003',
-    port: '',
-    path: 'http://localhost:4003',
-  }
+    server: "http://207.246.127.17",
+    port: "",
+    path: "api",
+  },
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,9 +1,14 @@
 export const environment = {
   production: true,
   encrypt_key: "5708c8d4-0b2a-4cbd-bea4-99981079020a",
+  // api: {
+  //   server: "http://207.246.127.17",
+  //   port: "",
+  //   path: "api",
+  // },
   api: {
-    server: "http://207.246.127.17",
-    port: "",
-    path: "api",
+    server: 'http://localhost:4003',
+    port: '',
+    path: 'http://localhost:4003',
   }
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,14 +1,9 @@
 export const environment = {
   production: true,
   encrypt_key: "5708c8d4-0b2a-4cbd-bea4-99981079020a",
-  // api: {
-  //   server: "http://207.246.127.17",
-  //   port: "",
-  //   path: "api",
-  // },
   api: {
-    server: 'http://localhost:4003',
-    port: '',
-    path: 'http://localhost:4003',
-  }
+    server: "http://207.246.127.17",
+    port: "",
+    path: "api",
+  },
 };

--- a/src/utils/document.util.ts
+++ b/src/utils/document.util.ts
@@ -1,12 +1,19 @@
-export default class DocuemntUtil {
+export default class DocumentUtil {
     static formatDocument(value: string) {
-
-        if (value.length === 11) {
+        if (!value) return '';
+        // CPF
+        if (value.length === 11 && /^\d+$/.test(value)) {
             return value.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, "$1.$2.$3-$4");
-        } else if (value.length === 14) {
-            return value.replace(/^(\d{2})(\d{3})?(\d{3})?(\d{4})?(\d{2})?/, "$1 $2 $3/$4-$5");
-        } else {
-            return value;
         }
+        // CNPJ antigo (apenas números)
+        if (value.length === 14 && /^\d+$/.test(value)) {
+            return value.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, "$1.$2.$3/$4-$5");
+        }
+        // CNPJ novo (alfanumérico: 12 letras/números + 2 dígitos)
+        if (value.length === 14 && /^[A-Z0-9]{12}\d{2}$/i.test(value)) {
+            // Exemplo visual: 7C.GDW.INC/SLG8-77
+            return value.replace(/^(.{2})(.{3})(.{3})(.{4})(.{2})$/, "$1.$2.$3/$4-$5");
+        }
+        return value;
     }
 }

--- a/src/utils/user-data-validator.utils.ts
+++ b/src/utils/user-data-validator.utils.ts
@@ -1,56 +1,37 @@
 export default class UserDataValidator {
   static validarCNPJ(cnpj: string): boolean {
- 
     if (!cnpj || typeof cnpj !== 'string') return false;
     cnpj = cnpj.replace(/[^A-Z0-9]/gi, '').toUpperCase();
 
-    const regexNovo = /^[A-Z0-9]{12}[0-9]{2}$/;
-    const regexAntigo = /^\d{14}$/;
+    // Aceita 14 caracteres alfanuméricos
+    if (!/^[A-Z0-9]{14}$/.test(cnpj)) return false;
+    if (/^(\w)\1+$/.test(cnpj)) return false; // todos iguais
 
-    if (regexNovo.test(cnpj)) {
-      // Novo padrão: alfanumérico
-      function charToValue(char: string): number {
-        if (/[0-9]/.test(char)) return parseInt(char, 10);
-        return char.charCodeAt(0) - 48;
-      }
-      const base = cnpj.substring(0, 12);
-      const dv1Input = base.split('').map(charToValue);
-      let sum1 = 0;
-      let weight = 2;
-      for (let i = dv1Input.length - 1; i >= 0; i--) {
-        sum1 += dv1Input[i] * weight;
-        weight = weight === 9 ? 2 : weight + 1;
-      }
-      let rest1 = sum1 % 11;
-      let dv1 = rest1 < 2 ? 0 : 11 - rest1;
-      const dv2Input = [...dv1Input, dv1];
-      let sum2 = 0;
-      weight = 2;
-      for (let i = dv2Input.length - 1; i >= 0; i--) {
-        sum2 += dv2Input[i] * weight;
-        weight = weight === 9 ? 2 : weight + 1;
-      }
-      let rest2 = sum2 % 11;
-      let dv2 = rest2 < 2 ? 0 : 11 - rest2;
-      const dvInformado = cnpj.substring(12);
-      return dvInformado === `${dv1}${dv2}`;
-    } else if (regexAntigo.test(cnpj)) {
-      // Antigo: apenas números
-      if (/^(\d)\1+$/.test(cnpj)) return false;
-      const calcDv = (base: string, pesos: number[]) => {
-        let sum = 0;
-        for (let i = 0; i < pesos.length; i++) {
-          sum += parseInt(base.charAt(i), 10) * pesos[i];
-        }
-        let rest = sum % 11;
-        return rest < 2 ? 0 : 11 - rest;
-      };
-      const base = cnpj.substring(0, 12);
-      const dv1 = calcDv(base, [5,4,3,2,9,8,7,6,5,4,3,2]);
-      const dv2 = calcDv(base + dv1, [6,5,4,3,2,9,8,7,6,5,4,3,2]);
-      return cnpj.substring(12) === `${dv1}${dv2}`;
+    // Função para converter caractere para valor numérico
+    function charToValue(char: string): number {
+      if (/[0-9]/.test(char)) return parseInt(char, 10);
+      return char.charCodeAt(0) - 48;
     }
-    return false;
+    const base = cnpj.substring(0, 12);
+    const dv1Input = base.split('').map(charToValue);
+    let sum1 = 0;
+    let weight = 2;
+    for (let i = dv1Input.length - 1; i >= 0; i--) {
+      sum1 += dv1Input[i] * weight;
+      weight = weight === 9 ? 2 : weight + 1;
+    }
+    let rest1 = sum1 % 11;
+    let dv1 = rest1 < 2 ? 0 : 11 - rest1;
+    const dv2Input = [...dv1Input, dv1];
+    let sum2 = 0;
+    weight = 2;
+    for (let i = dv2Input.length - 1; i >= 0; i--) {
+      sum2 += dv2Input[i] * weight;
+      weight = weight === 9 ? 2 : weight + 1;
+    }
+    let rest2 = sum2 % 11;
+    let dv2 = rest2 < 2 ? 0 : 11 - rest2;
+    const dvInformado = cnpj.substring(12);
+    return dvInformado === `${dv1}${dv2}`;
   }
- 
 }

--- a/src/utils/user-data-validator.utils.ts
+++ b/src/utils/user-data-validator.utils.ts
@@ -1,60 +1,56 @@
 export default class UserDataValidator {
-  static validarCNPJ(cnpj: string) {
+  static validarCNPJ(cnpj: string): boolean {
  
-    cnpj = cnpj.replace(/[^\d]+/g,'');
- 
-    if(cnpj == '') return false;
-     
-    if (cnpj.length != 14)
-        return false;
- 
-    // Elimina CNPJs invalidos conhecidos
-    if (cnpj == "00000000000000" || 
-        cnpj == "11111111111111" || 
-        cnpj == "22222222222222" || 
-        cnpj == "33333333333333" || 
-        cnpj == "44444444444444" || 
-        cnpj == "55555555555555" || 
-        cnpj == "66666666666666" || 
-        cnpj == "77777777777777" || 
-        cnpj == "88888888888888" || 
-        cnpj == "99999999999999")
-        return false;
-         
-    // Valida DVs
-    let tamanho = cnpj.length - 2
-    let numeros = cnpj.substring(0,tamanho);
-    const digitos = cnpj.substring(tamanho);
-    let soma = 0;
-    let pos = tamanho - 7;
-    for (let i = tamanho; i >= 1; i--) {
-      soma += Number(numeros.charAt(tamanho - i)) * pos--;
-      if (pos < 2)
-            pos = 9;
+    if (!cnpj || typeof cnpj !== 'string') return false;
+    cnpj = cnpj.replace(/[^A-Z0-9]/gi, '').toUpperCase();
+
+    const regexNovo = /^[A-Z0-9]{12}[0-9]{2}$/;
+    const regexAntigo = /^\d{14}$/;
+
+    if (regexNovo.test(cnpj)) {
+      // Novo padrão: alfanumérico
+      function charToValue(char: string): number {
+        if (/[0-9]/.test(char)) return parseInt(char, 10);
+        return char.charCodeAt(0) - 48;
+      }
+      const base = cnpj.substring(0, 12);
+      const dv1Input = base.split('').map(charToValue);
+      let sum1 = 0;
+      let weight = 2;
+      for (let i = dv1Input.length - 1; i >= 0; i--) {
+        sum1 += dv1Input[i] * weight;
+        weight = weight === 9 ? 2 : weight + 1;
+      }
+      let rest1 = sum1 % 11;
+      let dv1 = rest1 < 2 ? 0 : 11 - rest1;
+      const dv2Input = [...dv1Input, dv1];
+      let sum2 = 0;
+      weight = 2;
+      for (let i = dv2Input.length - 1; i >= 0; i--) {
+        sum2 += dv2Input[i] * weight;
+        weight = weight === 9 ? 2 : weight + 1;
+      }
+      let rest2 = sum2 % 11;
+      let dv2 = rest2 < 2 ? 0 : 11 - rest2;
+      const dvInformado = cnpj.substring(12);
+      return dvInformado === `${dv1}${dv2}`;
+    } else if (regexAntigo.test(cnpj)) {
+      // Antigo: apenas números
+      if (/^(\d)\1+$/.test(cnpj)) return false;
+      const calcDv = (base: string, pesos: number[]) => {
+        let sum = 0;
+        for (let i = 0; i < pesos.length; i++) {
+          sum += parseInt(base.charAt(i), 10) * pesos[i];
+        }
+        let rest = sum % 11;
+        return rest < 2 ? 0 : 11 - rest;
+      };
+      const base = cnpj.substring(0, 12);
+      const dv1 = calcDv(base, [5,4,3,2,9,8,7,6,5,4,3,2]);
+      const dv2 = calcDv(base + dv1, [6,5,4,3,2,9,8,7,6,5,4,3,2]);
+      return cnpj.substring(12) === `${dv1}${dv2}`;
     }
-    let resultado = soma % 11 < 2 ? 0 : 11 - soma % 11;
-    if (resultado != Number(digitos.charAt(0))) {
-      return false;
-    } 
-      
-         
-    tamanho = tamanho + 1;
-    numeros = cnpj.substring(0,tamanho);
-    soma = 0;
-    pos = tamanho - 7;
-    for (let i = tamanho; i >= 1; i--) {
-      soma += Number(numeros.charAt(tamanho - i)) * pos--;
-      if (pos < 2)
-            pos = 9;
-    }
-    resultado = soma % 11 < 2 ? 0 : 11 - soma % 11;
-    if (resultado != Number(digitos.charAt(1))) {
-      return false;
-    }
-          
-           
-    return true;
-    
-}
+    return false;
+  }
  
 }


### PR DESCRIPTION
## Implementação de Validação de CNPJ (#181)

### Descrição
Este PR implementa a nova validação de CNPJs no cadastro de fornecedores, conforme exigido na [User Story #181](#). A mudança foi motivada por feedback de cliente e por atualizações na [Instrução Normativa RFB nº 2119/2022](https://normasinternet2.receita.fazenda.gov.br/#/consulta/externa/127567), que agora permite CNPJs alfanuméricos.

### O que foi feito
- Centralização da validação de CNPJ em uma única função no frontend.
- Atualização do algoritmo de validação para aceitar CNPJs alfanuméricos, conforme o anexo da norma.
- Revisão dos pontos do sistema onde CNPJs são utilizados como input de usuário.
- Inclusão de testes unitários cobrindo:
  - CNPJs válidos (alfanuméricos e numéricos).
  - CNPJs com dígito verificador incorreto.
  - CNPJs com caracteres inválidos.

### Referências
- Instrução Normativa RFB nº 2119/2022: [link](https://normasinternet2.receita.fazenda.gov.br/#/consulta/externa/127567)
- Gerador de CNPJs alfanuméricos para testes: [geradorbrasil.com](https://geradorbrasil.com/gerador-de-cnpj-alfanumerico/)
