### PR TITLE
fix(#195): implementa filtragem dinâmica na pesquisa de fornecedores

### DIFF
--- a/src/app/project/fornecedor/fornecedor.component.html
+++ b/src/app/project/fornecedor/fornecedor.component.html
@@ -8,8 +8,9 @@
   <form [formGroup]="form">
     <div class="row mt-4">
       <div class="col-md-9">
-        <input type="text" class="form-control form-control-lg text-secondary input-height-border" 
+        <input type="text" class="form-control form-control-lg text-secondary input-height-border"
           formControlName="search"
+          #searchInput
           placeholder="{{'SUPPLIER.SEARCH_NAME' | translate}}">
       </div>
       <div class="col-md-3" *ngIf="authService.getAuthenticatedUser().roles !== 'visualizador_projetos'">

--- a/src/app/project/fornecedor/fornecedor.component.ts
+++ b/src/app/project/fornecedor/fornecedor.component.ts
@@ -1,28 +1,31 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, OnDestroy, AfterViewInit, ElementRef, ViewChild } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { DeleteFornecedorComponent } from './delete-fornecedor/delete-fornecedor.component';
 import { ToastrService } from 'ngx-toastr';
 import { SupplierService } from '../../../services/supplier.service';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
-import FilterFuzzy from 'src/utils/filterFuzzy.util';
 import Fuse from 'fuse.js';
 import { AuthService } from 'src/services/auth.service';
 import { SupplierGetResponseDto } from 'src/dtos/supplier/supplier-get-response.dto';                                     
-
 
 @Component({
   selector: 'app-fornecedor',
   templateUrl: './fornecedor.component.html',
   styleUrls: ['./fornecedor.component.scss']
 })
-export class FornecedorComponent {
+export class FornecedorComponent implements OnInit, OnDestroy, AfterViewInit {
 
   currentPage: number = 1;
   itensPerPage: number = 8;
-  fornecedor: SupplierGetResponseDto[];
-  fornecedorFilter: SupplierGetResponseDto[];
+  fornecedor: SupplierGetResponseDto[] = [];
+  fornecedorFilter: SupplierGetResponseDto[] = [];
   form: FormGroup;
+  private fuse: Fuse<SupplierGetResponseDto> | null = null;
+  private searchInputListener?: EventListener;
+  private valueChangesSubscription: any;
+
+  @ViewChild('searchInput', { static: false }) searchInputRef!: ElementRef;
 
   constructor(
     public authService: AuthService,
@@ -33,75 +36,103 @@ export class FornecedorComponent {
     private router: Router
   ) {
     this.form = this.formBuilder.group({
-      search: ['', [Validators.required, Validators.minLength(3)]],
+      search: [''],
     });
   }
 
   ngOnInit(): void {
-
     const id = localStorage.getItem('id_fornecedor');
     if(id && id == '0'){      
       localStorage.removeItem('id_fornecedor')
       this.fornecedorFilter = this._supplierService.getFornecedorFilterList();
       this.fornecedor = this._supplierService.getFornecedorList();
+      this.setupFuse();
     }else{
-      this.list()  
+      this.list();
     }
-    
-    // Busca dinâmica: inclui fuzzy search, fallback para includes/toLowerCase
-    this.form.controls['search'].valueChanges.subscribe((text: string) => {
-      if (text && text.trim().length > 0) {
-        // Fuzzy search usando Fuse.js se disponível
-        if (typeof Fuse !== 'undefined') {
-          const fuse = new Fuse(this.fornecedor, {
-            keys: ['name', 'cpf', 'address.city'],
-            threshold: 0.4,
-            ignoreLocation: true,
-            minMatchCharLength: 1
-          });
-          const result = fuse.search(text).map(res => res.item);
-          this.fornecedorFilter = result;
-        } else {
-          // Fallback: includes + toLowerCase
-          const lowerText = text.toLowerCase();
-          this.fornecedorFilter = this.fornecedor.filter(item =>
-            (item.name && item.name.toLowerCase().includes(lowerText)) ||
-            (item.cpf && item.cpf.toLowerCase().includes(lowerText)) ||
-            (item.address && item.address.city && item.address.city.toLowerCase().includes(lowerText))
-          );
-        }
-      } else {
-        this.fornecedorFilter = this.fornecedor;
-      }
+
+    this.valueChangesSubscription = this.form.controls['search'].valueChanges.subscribe((text: string) => {
+      this.applyFilter(text);
     });
+  }
 
-    // Desabilitar ação do Enter no campo de busca
-    setTimeout(() => {
-      const searchInput = document.querySelector('input[formControlName="search"]');
-      if (searchInput) {
-        searchInput.addEventListener('keydown', (event: Event) => {
-          const keyboardEvent = event as KeyboardEvent;
-          if (keyboardEvent.key === 'Enter') {
-            keyboardEvent.preventDefault();
-            // Não faz nada ao pressionar Enter
+  ngAfterViewInit(): void {
+    // Adiciona listener do Enter após view inicializada
+    const input = document.querySelector('input[formControlName="search"]');
+    if (input) {
+      this.searchInputListener = (event: Event) => {
+        const keyboardEvent = event as KeyboardEvent;
+        if (keyboardEvent.key === 'Enter') {
+          keyboardEvent.preventDefault();
+        }
+      };
+      input.addEventListener('keydown', this.searchInputListener);
+    }
+  }
+
+  ngOnDestroy(): void {
+    // Remove o listener do Enter para evitar vazamento de memória
+    const input = document.querySelector('input[formControlName="search"]');
+    if (input && this.searchInputListener) {
+      input.removeEventListener('keydown', this.searchInputListener);
+    }
+    if (this.valueChangesSubscription) {
+      this.valueChangesSubscription.unsubscribe();
+    }
+  }
+
+  private setupFuse(): void {
+    if (typeof Fuse !== 'undefined' && this.fornecedor && this.fornecedor.length > 0) {
+      this.fuse = new Fuse(this.fornecedor, {
+        keys: [
+          {
+            name: 'name',
+            getFn: (obj: any) => obj.name || ''
+          },
+          {
+            name: 'cpf',
+            getFn: (obj: any) => obj.cpf || ''
+          },
+          {
+            name: 'address.city',
+            getFn: (obj: any) => obj.address && obj.address.city ? obj.address.city : ''
           }
-        });
-      }
-    }, 0);
+        ],
+        threshold: 0.4,
+        ignoreLocation: true,
+        minMatchCharLength: 1
+      });
+    } else {
+      this.fuse = null;
+    }
+  }
 
-    
+  private applyFilter(text: string): void {
+    if (text && text.trim().length > 0) {
+      if (this.fuse) {
+        const result = this.fuse.search(text).map(res => res.item);
+        this.fornecedorFilter = result;
+      } else {
+        const lowerText = text.toLowerCase();
+        this.fornecedorFilter = this.fornecedor.filter(item =>
+          (item.name && item.name.toLowerCase().includes(lowerText)) ||
+          (item.cpf && item.cpf.toLowerCase().includes(lowerText)) ||
+          (item.address && item.address.city && item.address.city.toLowerCase().includes(lowerText))
+        );
+      }
+    } else {
+      this.fornecedorFilter = this.fornecedor;
+    }
   }
 
   list() {
     this._supplierService.supplierList().subscribe((response: any) => {
       this.fornecedor = response;
-      this.fornecedorFilter = response
-
+      this.fornecedorFilter = response;
       this._supplierService.setFornecedorFilterList(response);
       this._supplierService.setFornecedorList(response);
-
+      this.setupFuse();
     });
-    
   }
 
   openModal(fornecedor: any) {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -5,5 +5,5 @@ export const environment = {
     server: "http://207.246.127.17",
     port: "",
     path: "api",
-  },
+  }
 };


### PR DESCRIPTION
### Esta correção resolve o problema em que a pesquisa de fornecedores não filtrava corretamente os resultados e bloqueia temporariamente o "Enter".

#### Alterações realizadas:
- Ajuste na lógica de filtragem no componente de pesquisa de fornecedores.
- Bloqueio do "Enter" de acessar os detalhes do primeiro item encontrado.
- Revisão das condições de busca para garantir que os critérios sejam aplicados corretamente.

#### Como testar:
1. Acesse a tela de pesquisa de fornecedores.
2. Realize buscas utilizando diferentes termos e filtros.
3. Verifique se os resultados retornados correspondem corretamente aos critérios inseridos.

#### Observações:
Caso sejam encontrados comportamentos inesperados durante os testes, favor reportar na própria PR.
