### PR TITLE
refactor: MAP_INITIAL_COORDS via variável de ambiente no docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,4 +7,4 @@ services:
       - "80:8080"  # Mapeando a porta 8080 do container para a porta 80 da máquina local
     restart: always
     environment:
-      - MAP_INITIAL_COORDS=lat=-23.5505,lng=-46.6333,zoom=12
+      - MAP_INITIAL_COORDS=${MAP_INITIAL_COORDS}


### PR DESCRIPTION
Conforme sugestão do @juanmeleiro, alterado o valor fixo da variável `MAP_INITIAL_COORDS`  
para utilizar a interpolação de variável de ambiente do `docker-compose`  
(`${MAP_INITIAL_COORDS}`), permitindo configuração externa.
